### PR TITLE
Add code to post data to "How out of date are we?"

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,8 @@
 FROM ruby:2.7-alpine
 
 RUN apk --update add --virtual build_deps \
-    build-base ruby-dev libc-dev linux-headers
+    build-base ruby-dev libc-dev linux-headers \
+    curl
 
 RUN addgroup -g 1000 -S appgroup && \
     adduser -u 1000 -S appuser -G appgroup
@@ -21,4 +22,4 @@ RUN chown 1000:1000 state-files
 
 USER 1000
 
-CMD ["ruby", "./bin/list_orphaned_resources.rb"]
+CMD ["/bin/sh", "./bin/post-data-to-hoodaw.sh"]

--- a/bin/post-data-to-hoodaw.sh
+++ b/bin/post-data-to-hoodaw.sh
@@ -1,0 +1,5 @@
+#!/bin/sh
+
+set -euo pipefail
+
+curl -H "X-API-KEY: ${HOODAW_API_KEY}" -d "$(./bin/list_orphaned_resources.rb)" ${HOODAW_HOST}/orphaned_resources

--- a/makefile
+++ b/makefile
@@ -10,4 +10,6 @@ run: build
 	docker run --rm \
 		-e AWS_ACCESS_KEY=$${AWS_ACCESS_KEY} \
 		-e AWS_SECRET_ACCESS_KEY=$${AWS_SECRET_ACCESS_KEY} \
+		-e HOODAW_API_KEY=$${HOODAW_API_KEY} \
+		-e HOODAW_HOST=$${HOODAW_HOST} \
 		-it $(IMAGE)


### PR DESCRIPTION
Unlike the existing [HOODAW updater], this expects
an env var containing the HOODAW API key.

Although this adds a new dependency, it means we
don't need to add kubectl to this docker image, or
cluster credentials. 

In general, I think moving to separate jobs to
post data to HOODAW is a more sensible approach
than the current one of adding more and more
report types to a single updater script in the 
HOODAW updater docker image.


[HOODAW updater]: https://github.com/ministryofjustice/cloud-platform-how-out-of-date-are-we/blob/main/updater-image/update.sh