### PR TITLE
Exclude security groups from orphaned AWS list

### DIFF
--- a/lib/orphaned_resources/aws_resources.rb
+++ b/lib/orphaned_resources/aws_resources.rb
@@ -11,8 +11,6 @@ module OrphanedResources
     SUBNET_URL = VPC_HOME + "#subnets:search="
     VPC_URL = VPC_HOME + "#VpcDetails:VpcId="
 
-    SECURITY_GROUP_URL = EC2_HOME + "#SecurityGroup:groupId="
-
     def initialize(params)
       @s3client = params.fetch(:s3client)
       @ec2client = params.fetch(:ec2client)
@@ -70,16 +68,6 @@ module OrphanedResources
           )
         }
       clean_list(list)
-    end
-
-    def security_groups
-      list = ec2client.describe_security_groups
-        .security_groups
-        .map(&:group_id)
-      clean_list(list).map { |id|
-        url = SECURITY_GROUP_URL + id
-        ResourceTuple.new(id: id, aws_console_url: url)
-      }
     end
 
     private

--- a/lib/orphaned_resources/reporter.rb
+++ b/lib/orphaned_resources/reporter.rb
@@ -23,7 +23,6 @@ module OrphanedResources
         internet_gateways: compare(:internet_gateways),
         subnets: compare(:subnets),
         vpcs: compare(:vpcs),
-        security_groups: compare(:security_groups),
         route_tables: compare(:route_tables),
         route_table_associations: compare(:route_table_associations),
       }

--- a/lib/orphaned_resources/terraform_state_manager.rb
+++ b/lib/orphaned_resources/terraform_state_manager.rb
@@ -50,11 +50,6 @@ module OrphanedResources
       clean_list(list).map { |id| ResourceTuple.new(id: id) }
     end
 
-    def security_groups
-      list = local_statefiles.inject([]) { |ids, file| ids << security_groups_from_statefile(file) }
-      clean_list(list).map { |id| ResourceTuple.new(id: id) }
-    end
-
     private
 
     def internet_gateways_from_statefile(file)
@@ -98,14 +93,6 @@ module OrphanedResources
         .map { |zone| zone["instances"] }
         .flatten
         .map { |inst| inst.dig("attributes", "name") }
-    end
-
-    def security_groups_from_statefile(file)
-      json_resources(file)
-        .find_all { |res| res["type"] == "aws_security_group" }
-        .map { |res| res["instances"] }
-        .flatten
-        .map { |inst| inst.dig("attributes", "id") }
     end
 
     def download_files


### PR DESCRIPTION
Security groups are created by some of the
components of the cloud platform, and are often
*not mentioned* in any `terraform.tfstate` files.

So, listing them in the "orphaned AWS resources"
page makes it likely that we will delete something
important, by accident.

The simplest solution is to not list any security
groups at all, until we have a more reliable way
to identify security groups which are definitely
not useful (check to see if the VPC they relate
to still exists? Do security groups persist if
the VPC they relate to is deleted?)