### PR TITLE
Add RDS instances to the orphaned AWS resources report

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -4,6 +4,7 @@ source "https://rubygems.org"
 
 git_source(:github) { |repo_name| "https://github.com/#{repo_name}" }
 
+gem "aws-sdk-rds"
 gem "aws-sdk-ec2"
 gem "aws-sdk-s3"
 gem "aws-sdk-autoscaling", "~> 1.44"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -17,6 +17,9 @@ GEM
     aws-sdk-kms (1.36.0)
       aws-sdk-core (~> 3, >= 3.99.0)
       aws-sigv4 (~> 1.1)
+    aws-sdk-rds (1.100.0)
+      aws-sdk-core (~> 3, >= 3.99.0)
+      aws-sigv4 (~> 1.1)
     aws-sdk-route53 (1.40.0)
       aws-sdk-core (~> 3, >= 3.99.0)
       aws-sigv4 (~> 1.1)
@@ -52,6 +55,7 @@ PLATFORMS
 DEPENDENCIES
   aws-sdk-autoscaling (~> 1.44)
   aws-sdk-ec2
+  aws-sdk-rds
   aws-sdk-route53 (~> 1.40)
   aws-sdk-s3
   json (>= 2.3.1)

--- a/lib/orphaned_resources.rb
+++ b/lib/orphaned_resources.rb
@@ -3,6 +3,7 @@ require "json"
 require "aws-sdk-ec2"
 require "aws-sdk-s3"
 require "aws-sdk-route53"
+require "aws-sdk-rds"
 
 require_relative "./orphaned_resources/lister"
 require_relative "./orphaned_resources/terraform_state_manager"

--- a/lib/orphaned_resources/aws_resources.rb
+++ b/lib/orphaned_resources/aws_resources.rb
@@ -78,17 +78,23 @@ module OrphanedResources
     end
 
     def rds
-      list = rdsclient
-        .describe_db_instances
-        .db_instances
-        .map { |db|
-          id = db.db_instance_identifier
-          ResourceTuple.new(
-            id: id,
-            aws_console_url: RDS_HOME + "#database:id=#{id};is-cluster=false"
-          )
-        }
-      clean_list(list)
+      list = []
+      marker = nil
+
+      loop do
+        rtn = rdsclient.describe_db_instances(marker: marker)
+        list += rtn.db_instances
+        marker = rtn.marker
+        break if marker.nil?
+      end
+
+      list.map { |db|
+        id = db.db_instance_identifier
+        ResourceTuple.new(
+          id: id,
+          aws_console_url: RDS_HOME + "#database:id=#{id};is-cluster=false"
+        )
+      }
     end
 
     private

--- a/lib/orphaned_resources/aws_resources.rb
+++ b/lib/orphaned_resources/aws_resources.rb
@@ -1,9 +1,10 @@
 module OrphanedResources
   class AwsResources < Lister
-    attr_reader :s3client, :ec2client, :route53client
+    attr_reader :s3client, :ec2client, :route53client, :rdsclient
 
     VPC_HOME = "https://eu-west-2.console.aws.amazon.com/vpc/home?region=eu-west-2"
     EC2_HOME = "https://eu-west-2.console.aws.amazon.com/ec2/v2/home?region=eu-west-2"
+    RDS_HOME = "https://eu-west-2.console.aws.amazon.com/rds/home?region=eu-west-2"
 
     NAT_GATEWAY_URL = VPC_HOME + "#NatGatewayDetails:natGatewayId="
     INTERNET_GATEWAY_URL = VPC_HOME + "#InternetGateway:internetGatewayId="
@@ -19,6 +20,7 @@ module OrphanedResources
       @s3client = params.fetch(:s3client)
       @ec2client = params.fetch(:ec2client)
       @route53client = params.fetch(:route53client)
+      @rdsclient = params.fetch(:rdsclient)
     end
 
     def vpcs
@@ -70,6 +72,20 @@ module OrphanedResources
           HostedZoneTuple.new(
             id: z.name.sub(/\.$/, ""), # trim trailing '.'
             hosted_zone_id: z.id
+          )
+        }
+      clean_list(list)
+    end
+
+    def rds
+      list = rdsclient
+        .describe_db_instances
+        .db_instances
+        .map { |db|
+          id = db.db_instance_identifier
+          ResourceTuple.new(
+            id: id,
+            aws_console_url: RDS_HOME + "#database:id=#{id};is-cluster=false"
           )
         }
       clean_list(list)

--- a/lib/orphaned_resources/reporter.rb
+++ b/lib/orphaned_resources/reporter.rb
@@ -4,11 +4,13 @@ module OrphanedResources
       s3 = Aws::S3::Resource.new(region: "eu-west-1", profile: ENV["AWS_PROFILE"])
       ec2 = Aws::EC2::Client.new(region: "eu-west-2", profile: ENV["AWS_PROFILE"])
       route53 = Aws::Route53::Client.new(region: "eu-west-2", profile: ENV["AWS_PROFILE"])
+      rds = Aws::RDS::Client.new(region: "eu-west-2", profile: ENV["AWS_PROFILE"])
 
       @aws = OrphanedResources::AwsResources.new(
         s3client: s3,
         ec2client: ec2,
         route53client: route53,
+        rdsclient: rds,
       )
 
       @terraform = OrphanedResources::TerraformStateManager.new(

--- a/lib/orphaned_resources/reporter.rb
+++ b/lib/orphaned_resources/reporter.rb
@@ -27,6 +27,7 @@ module OrphanedResources
         vpcs: compare(:vpcs),
         route_tables: compare(:route_tables),
         route_table_associations: compare(:route_table_associations),
+        rds: compare(:rds),
       }
     end
 

--- a/lib/orphaned_resources/terraform_state_manager.rb
+++ b/lib/orphaned_resources/terraform_state_manager.rb
@@ -50,6 +50,11 @@ module OrphanedResources
       clean_list(list).map { |id| ResourceTuple.new(id: id) }
     end
 
+    def rds
+      list = local_statefiles.inject([]) { |ids, file| ids << rds_from_statefile(file) }
+      clean_list(list).map { |id| ResourceTuple.new(id: id) }
+    end
+
     private
 
     def internet_gateways_from_statefile(file)
@@ -93,6 +98,14 @@ module OrphanedResources
         .map { |zone| zone["instances"] }
         .flatten
         .map { |inst| inst.dig("attributes", "name") }
+    end
+
+    def rds_from_statefile(file)
+      json_resources(file)
+      .find_all { |r| r["type"] == "aws_db_instance" }
+      .map { |rds| rds["instances"] }.flatten
+      .map { |i| i.dig("attributes", "address") }
+      .map { |name| name.sub(/\..*/, "") }
     end
 
     def download_files


### PR DESCRIPTION
- Add RDS gem
- Enable listing RDS instances via AWS client gem
- Enable listing RDS instances from terraform states
- Use pagination to fetch all RDS instance details
- Include orphaned RDS instances in report JSON
