### PR TITLE
Fixes for "orphaned" hosted zones

### DIFF
--- a/lib/orphaned_resources/aws_resources.rb
+++ b/lib/orphaned_resources/aws_resources.rb
@@ -16,6 +16,11 @@ module OrphanedResources
     # managed in code, but it cannot be deleted.
     DEFAULT_VPC_ID = "vpc-057ac86d"
 
+    # These zones are not managed in terraform, and we're OK with that.
+    IGNORE_ZONE_NAMES = [
+      "integrationtest.service.justice.gov.uk"
+    ]
+
     def initialize(params)
       @s3client = params.fetch(:s3client)
       @ec2client = params.fetch(:ec2client)
@@ -73,7 +78,7 @@ module OrphanedResources
             id: z.name.sub(/\.$/, ""), # trim trailing '.'
             hosted_zone_id: z.id
           )
-        }
+        }.reject { |z| IGNORE_ZONE_NAMES.include?(z.id) }
       clean_list(list)
     end
 

--- a/lib/orphaned_resources/terraform_state_manager.rb
+++ b/lib/orphaned_resources/terraform_state_manager.rb
@@ -103,6 +103,7 @@ module OrphanedResources
         .map { |zone| zone["instances"] }
         .flatten
         .map { |inst| inst.dig("attributes", "name") }
+        .map { |name| name.sub(/\.$/, "") } # trim trailing '.'
     end
 
     def rds_from_statefile(file)


### PR DESCRIPTION
This PR fixes 2 issues with the list of orphaned hosted zones.

* Add an ignore list for any zones we know are not managed in terraform
* Consistently remove trailing `.` from zone names, so we're comparing AWS and terraform data on a like for like basis

- Don't include integration test hosted zone
- Remove trailing `.` from terraform zone names
